### PR TITLE
Call module member instead of type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mownstr"
 description = "Maybe Owned String"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Pierre-Antoine Champin <pchampin@liris.cnrs.fr>"]
 edition = "2018"
 repository = "https://github.com/pchampin/mownstr"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::str;
 /// Trying to convert such a large string to a `MownStr` will panic.
 pub struct MownStr<'a>(&'a str);
 
-const LEN_MASK: usize = usize::MAX >> 1;
+const LEN_MASK: usize = std::usize::MAX >> 1;
 const OWN_FLAG: usize = !LEN_MASK;
 
 impl<'a> MownStr<'a> {


### PR DESCRIPTION
This probably needs rebasing on top of 0.1.1, but fixes compilation issue:
```
   |
23 | const LEN_MASK: usize = usize::MAX >> 1;
   |                                ^^^ associated item not found in `usize`
   |
help: you are looking for the module in `std`, not the primitive type
   |
23 | const LEN_MASK: usize = std::usize::MAX >> 1;
   |                         ^^^^^^^^^^^^^^^
```